### PR TITLE
Added loop until empty mode. fixed runloop time limit truncation.

### DIFF
--- a/runloop/MainRunLoop.hx
+++ b/runloop/MainRunLoop.hx
@@ -149,6 +149,7 @@ class MainRunLoop extends RunLoop
     private function recyclePriorityElement(prioElem : DelayPriorityQueueElement)
     {
         taskPool.push(prioElem);
+        prioElem.func = null;
     }
 
     override private function clear()

--- a/runloop/MainRunLoop.hx
+++ b/runloop/MainRunLoop.hx
@@ -49,6 +49,10 @@ class DelayPriorityQueueElement implements Prioritizable
 
 class MainRunLoop extends RunLoop
 {
+		// Sets the amount of time allocated per frame for running queued tasks.
+		// Set this to e.g. 1.0 second while loading to spend less time rendering.
+	public var loopDeltaForTasks (default, default): Float;
+
     private var firstLoopHappened : Bool;
 
     private var taskPool : Array<DelayPriorityQueueElement>;
@@ -59,6 +63,8 @@ class MainRunLoop extends RunLoop
     private function new() : Void
     {
         super();
+
+		loopDeltaForTasks = 1.0 / 60.0;	// 60 FPS by default
 
         firstLoopHappened = false;
 
@@ -97,16 +103,16 @@ class MainRunLoop extends RunLoop
 
     public function loopMainLoop(loopUntilEmpty: Bool = false) : Void
     {
-        var timeLeft: Float = 0.0; /// 60 fps, should be a settable variable later
+        var timeLeft: Float = 0.0;
 
         if(!firstLoopHappened)
         {
             firstLoopHappened = true;
-            timeLeft = (1.0 / 60.0); /// 60 fps, should be a settable variable later
+            timeLeft = loopDeltaForTasks;
         }
         else
         {
-            timeLeft = (1.0 / 60.0) - deltaOfLoop;
+            timeLeft = Math.max(loopDeltaForTasks - deltaOfLoop, 0.0);
         }
 
         loopOnce(timeLeft, loopUntilEmpty);

--- a/runloop/MainRunLoop.hx
+++ b/runloop/MainRunLoop.hx
@@ -23,7 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 package runloop;
 
 import haxe.Timer;
@@ -95,7 +95,7 @@ class MainRunLoop extends RunLoop
         #end
     }
 
-    public function loopMainLoop() : Void
+    public function loopMainLoop(loopUntilEmpty: Bool = false) : Void
     {
         var timeLeft: Float = 0.0; /// 60 fps, should be a settable variable later
 
@@ -109,15 +109,15 @@ class MainRunLoop extends RunLoop
             timeLeft = (1.0 / 60.0) - deltaOfLoop;
         }
 
-        loopOnce(timeLeft);
+        loopOnce(timeLeft, loopUntilEmpty);
     }
 
     /// adds the loopOnceDelays
-    override function loopOnce(timeLimit: Float) : Void
+    override function loopOnce(timeLimit: Float, loopUntilEmpty: Bool = false) : Void
     {
         loopOnceDelays();
 
-        super.loopOnce(timeLimit);
+        super.loopOnce(timeLimit, loopUntilEmpty);
     }
 
     public function delay(func : Void->Void, delay : Float)


### PR DESCRIPTION
The runloop time limit truncation should be there since forever, but it was not active because of a typo in a condition :(

It may require passing a minimum time limit to loopOnce (e.g. 1.0/120.0). If you have a very bad framerate, it will only run one queued function per frame, which can lead to accumulation if you queue more than the ammount of frames you have. 